### PR TITLE
Auto Cancellation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,43 @@
 ## OkLayoutInflater
 
-AndroidX [AsyncLayoutInflater](https://developer.android.com/reference/androidx/asynclayoutinflater/view/AsyncLayoutInflater) has some limitations. Here is an improved version of AsyncLayoutInflater with coroutine.
+AndroidX [AsyncLayoutInflater](https://developer.android.com/reference/androidx/asynclayoutinflater/view/AsyncLayoutInflater)
+has some limitations. Here is an improved version of AsyncLayoutInflater with Coroutines.
 
 1. Single thread to do all the inflate work
-2. Inflatework is not lifecycle aware/There is no way to cancel ongoing inflation
+2. Inflate work is not lifecycle aware/There is no way to cancel ongoing inflation
 3. Does not support LayoutInflater.Factory2.
-4. The default size limit of the cache queue is 10. If it exceeds 10, it will cause the main thread to wait.
+4. The default size limit of the cache queue is 10. If it exceeds 10, it will cause the main thread
+   to wait.
 
 Using OkLayoutInflater, we have improved threading limitations.
 
-
 ### Usage
- **Example of usage in fragment**
+
+**Example in Fragment**
 
 ```
-private val okLayoutInflater by lazy { OkLayoutInflater(requireContext()) }
+private val okLayoutInflater by lazy { OkLayoutInflater(this) }
 
 override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val v = inflater.inflate(R.layout.loader_view, container, false)
-
-        okLayoutInflater.inflate(
-            contentLayoutId,
-            container
-        ) {
-            (v as? ViewGroup)?.addView(it)
-        }
-        return v
-}
-
-override fun onDestroyView() {
-    okLayoutInflater.cancel()
-    super.onDestroyView()
+    val loadingView = inflater.inflate(R.layout.loader_view, container, false)
+    okLayoutInflater.inflate(contentLayoutId, container) {
+        (loadingView as? ViewGroup)?.addView(it)
+    }
+    return loadingView
 }
 ```
 
- **Example of usage in view**
+**Example of usage in View**
 
 ```
 private val okLayoutInflater by lazy { OkLayoutInflater(context) }
 
 override fun onAttachedToWindow() {
     super.onAttachedToWindow()
-    LayoutInflater.from(context).inflate(R.layout.viewstub_customer_tx_view, this, true)
-    okLayoutInflater.inflate(
-        merchant.okcredit.accounting.R.layout.transaction_view,
-        this
-    ) {
+    okLayoutInflater.inflate(R.layout.transaction_view, this) { inflatedView ->
         removeAllViews()
-        addView(it, LayoutParams.MATCH_PARENT)
+        addView(inflatedView, LayoutParams.MATCH_PARENT)
     }
-}
-
-override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    okLayoutInflater.cancel()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ AndroidX [AsyncLayoutInflater](https://developer.android.com/reference/androidx/
 has some limitations. Here is an improved version of AsyncLayoutInflater with Coroutines.
 
 1. Single thread to do all the inflate work
-2. Inflate work is not lifecycle aware/There is no way to cancel ongoing inflation
-3. Does not support LayoutInflater.Factory2.
+2. Inflate work is not lifecycle aware, there is no way to cancel ongoing inflation
+3. Does not support LayoutInflater.Factory2
 4. The default size limit of the cache queue is 10. If it exceeds 10, it will cause the main thread
-   to wait.
+   to wait
 
 Using OkLayoutInflater, we have improved threading limitations.
 
@@ -20,8 +20,8 @@ private val okLayoutInflater by lazy { OkLayoutInflater(this) }
 
 override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
     val loadingView = inflater.inflate(R.layout.loader_view, container, false)
-    okLayoutInflater.inflate(contentLayoutId, container) {
-        (loadingView as? ViewGroup)?.addView(it)
+    okLayoutInflater.inflate(contentLayoutId, container) { inflatedView ->
+        (loadingView as? ViewGroup)?.addView(inflatedView)
     }
     return loadingView
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Using OkLayoutInflater, we have improved threading limitations.
 
 ### Usage
 
-**Example in Fragment**
+**Example in a Fragment**
 
 ```
 private val okLayoutInflater by lazy { OkLayoutInflater(this) }
@@ -27,10 +27,10 @@ override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, saved
 }
 ```
 
-**Example of usage in View**
+**Example of usage in a View**
 
 ```
-private val okLayoutInflater by lazy { OkLayoutInflater(context) }
+private val okLayoutInflater by lazy { OkLayoutInflater(this) }
 
 override fun onAttachedToWindow() {
     super.onAttachedToWindow()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,9 +12,6 @@ android {
         targetSdk 32
         versionCode 1
         versionName "1.0"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
     }
 
     buildTypes {
@@ -27,9 +24,11 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }
+
     buildFeatures {
         viewBinding true
     }
@@ -37,13 +36,7 @@ android {
 
 dependencies {
     implementation project(':oklayoutinflator')
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/src/main/java/tech/okcredit/oklayoutinflator/MainActivity.kt
+++ b/app/src/main/java/tech/okcredit/oklayoutinflator/MainActivity.kt
@@ -2,27 +2,21 @@ package tech.okcredit.oklayoutinflator
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import tech.okcredit.oklayoutinflator.databinding.ActivityMainBinding
 import tech.okcredit.layout_inflator.OkLayoutInflater
+import tech.okcredit.oklayoutinflator.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
 
-    private var _binding: ActivityMainBinding? = null
-
-    private val binding get() = _binding!!
-
+    private lateinit var binding: ActivityMainBinding
     private val okLayoutInflater by lazy { OkLayoutInflater(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         setContentView(R.layout.layout_loading_view)
-        okLayoutInflater.inflate(
-            R.layout.activity_main,
-            null,
-        ) {
-            setContentView(it)
-            _binding = ActivityMainBinding.inflate(layoutInflater)
+
+        okLayoutInflater.inflate(R.layout.activity_main, null) { view ->
+            binding = ActivityMainBinding.bind(view)
+            setContentView(binding.root)
             setupUi()
         }
     }
@@ -31,11 +25,5 @@ class MainActivity : AppCompatActivity() {
         supportFragmentManager.beginTransaction()
             .replace(binding.mainContent.container.id, MainFragment.newInstance())
             .commitNow()
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        _binding = null
-        okLayoutInflater.cancel()
     }
 }

--- a/app/src/main/java/tech/okcredit/oklayoutinflator/MainFragment.kt
+++ b/app/src/main/java/tech/okcredit/oklayoutinflator/MainFragment.kt
@@ -1,15 +1,15 @@
 package tech.okcredit.oklayoutinflator
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import tech.okcredit.layout_inflator.OkLayoutInflater
 
 class MainFragment : Fragment() {
 
-    private val okLayoutInflater by lazy { OkLayoutInflater(requireContext()) }
+    private val okLayoutInflater by lazy { OkLayoutInflater(this) }
 
     companion object {
         fun newInstance() = MainFragment()
@@ -19,20 +19,15 @@ class MainFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val v = inflater.inflate(R.layout.layout_loading_view, container, false)
+        val loaderView = inflater.inflate(R.layout.layout_loading_view, container, false)
 
-        okLayoutInflater.inflate(
-            R.layout.main_fragment,
-            container
-        ) {
-            (v as? ViewGroup)?.removeAllViewsInLayout()
-            (v as? ViewGroup)?.addView(it)
+        okLayoutInflater.inflate(R.layout.main_fragment, container) { inflatedView ->
+            with(loaderView as ViewGroup) {
+                removeAllViewsInLayout()
+                addView(inflatedView)
+            }
         }
-        return v
-    }
 
-    override fun onDestroyView() {
-        okLayoutInflater.cancel()
-        super.onDestroyView()
+        return loaderView
     }
 }

--- a/app/src/main/res/layout/layout_loading_view.xml
+++ b/app/src/main/res/layout/layout_loading_view.xml
@@ -6,7 +6,7 @@
 
     <ProgressBar
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_gravity="center" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent">

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.1.2' apply false
-    id 'com.android.library' version '7.1.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.5.30' apply false
+    id 'com.android.application' version '7.2.1' apply false
+    id 'com.android.library' version '7.2.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.0' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 23 18:15:32 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/oklayoutinflator/build.gradle
+++ b/oklayoutinflator/build.gradle
@@ -29,5 +29,5 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3'
 }

--- a/oklayoutinflator/build.gradle
+++ b/oklayoutinflator/build.gradle
@@ -9,11 +9,6 @@ android {
     defaultConfig {
         minSdk 21
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles "consumer-rules.pro"
     }
 
     buildTypes {
@@ -21,22 +16,18 @@ android {
             testCoverageEnabled true
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = '1.8'
-    }
-    buildFeatures {
-        viewBinding true
     }
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.6.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1'
-    testImplementation 'junit:junit:4.13.2'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2'
 }

--- a/oklayoutinflator/src/main/java/tech/okcredit/layout_inflator/OkLayoutInflater.kt
+++ b/oklayoutinflator/src/main/java/tech/okcredit/layout_inflator/OkLayoutInflater.kt
@@ -9,20 +9,58 @@ import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.LayoutInflaterCompat
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.*
 
 /**
- * Androidx AsyncLayoutInflater has the following limitations.
- * 1. Use a single thread for all works. Here we are introducing coroutine
- * 2. If the queue exceeds 10 items, the main thread will be delayed.
- * 3. does not support setting a {@link LayoutInflater.Factory} nor {@link LayoutInflater.Factory2}. Here we are Adding support
- * 4. There is no way to cancel ongoing inflation. here we are exposing coroutine job cancel method
+ * OkLayoutInflater solves below mentioned limitations of the **AsyncLayoutInflater**.
+ *
+ * AndroidX's AsyncLayoutInflater has the following limitations.
+ * 1. It uses a single thread for all works.
+ * 2. If the queue exceeds 10 items, the Main Thread will be delayed.
+ * 3. It does not support setting a [LayoutInflater.Factory] nor [LayoutInflater.Factory2].
+ * 4. There is no way to cancel ongoing inflation.
  */
-class OkLayoutInflater(context: Context) {
+class OkLayoutInflater : LifecycleEventObserver {
 
-    private val mInflater: LayoutInflater = BasicInflater(context)
+    private val tag = "AsyncInf"
+
+    private lateinit var context: Context
+    private var fragment: Fragment? = null
+    private var componentLifecycle: Lifecycle? = null
+
+    private val mInflater by lazy { BasicInflater(context) }
     private val coroutineContext = SupervisorJob()
     private val scope = CoroutineScope(Dispatchers.Default + coroutineContext)
+
+    constructor(context: Context) {
+        init(context)
+    }
+
+    constructor(fragment: Fragment) {
+        this.fragment = fragment
+        init(fragment.requireContext())
+    }
+
+    private fun init(context: Context) {
+        this.context = context
+        if (context is LifecycleOwner) {
+            // Fragments 'may' outlive the View in some cases, so we use the View's Lifecycle
+            (fragment?.viewLifecycleOwner?.lifecycle ?: context.lifecycle).let { lifecycle ->
+                componentLifecycle = lifecycle
+                componentLifecycle!!.addObserver(this)
+            }
+        } else {
+            Log.d(
+                tag,
+                "Current context does not seem to have a Lifecycle, make sure to call `cancelInflation()` " +
+                        "in your onDestroy or other appropriate callback."
+            )
+        }
+    }
 
     fun inflate(
         @LayoutRes resId: Int,
@@ -35,7 +73,8 @@ class OkLayoutInflater(context: Context) {
         }
     }
 
-    fun cancel() {
+    fun cancelInflation() {
+        coroutineContext.cancel()
         coroutineContext.cancelChildren()
     }
 
@@ -47,27 +86,23 @@ class OkLayoutInflater(context: Context) {
     } catch (ex: RuntimeException) {
         Log.e("AsyncInf", "AsyncInf Failed to inflate on bg thread. message=${ex.message}")
 
-        // Some views need to be inflation-only in the main thread, fall back to inflation in the main thread if there is an exception
-        withContext(Dispatchers.Main) {
-            mInflater.inflate(resId, parent, false)
-        }
+        // Some views need to be inflation-only in the main thread,
+        // fall back to inflation in the main thread if there is an exception
+        withContext(Dispatchers.Main) { mInflater.inflate(resId, parent, false) }
     }
 
-    private class BasicInflater constructor(context: Context?) : LayoutInflater(context) {
+    private class BasicInflater constructor(context: Context) : LayoutInflater(context) {
 
         override fun cloneInContext(newContext: Context): LayoutInflater {
             return BasicInflater(newContext)
         }
 
-        @Throws(ClassNotFoundException::class)
         override fun onCreateView(name: String, attrs: AttributeSet): View {
             for (prefix in sClassPrefixList) {
                 try {
                     val view = createView(name, prefix, attrs)
-                    if (view != null) {
-                        return view
-                    }
-                } catch (e: ClassNotFoundException) {
+                    if (view != null) return view
+                } catch (_: ClassNotFoundException) {
                 }
             }
             return super.onCreateView(name, attrs)
@@ -75,9 +110,7 @@ class OkLayoutInflater(context: Context) {
 
         companion object {
             private val sClassPrefixList = arrayOf(
-                "android.widget.",
-                "android.webkit.",
-                "android.app."
+                "android.widget.", "android.webkit.", "android.app."
             )
         }
 
@@ -88,6 +121,13 @@ class OkLayoutInflater(context: Context) {
                     LayoutInflaterCompat.setFactory2(this, appCompatDelegate)
                 }
             }
+        }
+    }
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        if (event == Lifecycle.Event.ON_DESTROY) {
+            cancelInflation()
+            componentLifecycle?.removeObserver(this)
         }
     }
 }

--- a/oklayoutinflator/src/main/java/tech/okcredit/layout_inflator/OkLayoutInflater.kt
+++ b/oklayoutinflator/src/main/java/tech/okcredit/layout_inflator/OkLayoutInflater.kt
@@ -57,7 +57,7 @@ class OkLayoutInflater : LifecycleEventObserver {
      */
     constructor(view: View) {
         this.context = view.context
-        view.onViewDetachedFromWindow { cancelInflation() }
+        view.onViewDetachedFromWindow { cancel() }
     }
 
     private fun init(context: Context) {
@@ -88,7 +88,7 @@ class OkLayoutInflater : LifecycleEventObserver {
         }
     }
 
-    fun cancelInflation() {
+    fun cancel() {
         coroutineContext.cancel()
         coroutineContext.cancelChildren()
     }
@@ -141,7 +141,7 @@ class OkLayoutInflater : LifecycleEventObserver {
 
     override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
         if (event == Lifecycle.Event.ON_DESTROY) {
-            cancelInflation()
+            cancel()
             componentLifecycle?.removeObserver(this)
         }
     }

--- a/oklayoutinflator/src/main/java/tech/okcredit/layout_inflator/View.kt
+++ b/oklayoutinflator/src/main/java/tech/okcredit/layout_inflator/View.kt
@@ -1,0 +1,19 @@
+package tech.okcredit.layout_inflator
+
+import android.view.View
+import androidx.core.view.ViewCompat
+
+// taken directly from the core-ktx artifact
+internal inline fun View.onViewDetachedFromWindow(crossinline actionOnDetach: () -> Unit) {
+    if (!ViewCompat.isAttachedToWindow(this)) {
+        actionOnDetach()
+    } else {
+        addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(view: View) {}
+            override fun onViewDetachedFromWindow(view: View) {
+                removeOnAttachStateChangeListener(this)
+                actionOnDetach()
+            }
+        })
+    }
+}


### PR DESCRIPTION
1. Added auto-cancellation via Lifecycle.
Any component like Activity, Fragment, or Service that has a `Lifecycle` can be now used to auto-cancel the inflation in the `onDestroy` state.
In the case of a `Fragment`, we use `viewLifecycleOwner.lifecycle` as it makes more sense to cancel inflation there.

2. Removed unnecessary dependencies
3. Updated Readme.md

Also fixes: #1 